### PR TITLE
Add raw query engine operation

### DIFF
--- a/schemas/engine-ops/RawQueryRequest.json
+++ b/schemas/engine-ops/RawQueryRequest.json
@@ -1,0 +1,31 @@
+{
+    "$id": "http://open-data-fabric.github.com/schemas/RawQueryRequest",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Sent by the coordinator to an engine to perform query on raw input data, usually as part of ingest preprocessing step",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "inputDataPaths",
+        "transform",
+        "outputDataPath"
+    ],
+    "properties": {
+        "inputDataPaths": {
+            "type": "array",
+            "description": "Paths to input data files to perform query over. Must all have identical schema.",
+            "items": {
+                "type": "string",
+                "format": "path"
+            }
+        },
+        "transform": {
+            "$ref": "/schemas/Transform",
+            "description": "Transformation that will be applied to produce new data."
+        },
+        "outputDataPath": {
+            "type": "string",
+            "format": "path",
+            "description": "Path where query result will be written."
+        }
+    }
+}

--- a/schemas/engine-ops/RawQueryResponse.json
+++ b/schemas/engine-ops/RawQueryResponse.json
@@ -1,7 +1,7 @@
 {
-    "$id": "http://open-data-fabric.github.com/schemas/ExecuteQueryResponse",
+    "$id": "http://open-data-fabric.github.com/schemas/RawQueryResponse",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Sent by an engine to coordinator when performing the data transformation",
+    "description": "Sent by an engine to coordinator when performing the raw query operation",
     "root": true,
     "$defs": {
         "Progress": {
@@ -13,16 +13,14 @@
         "Success": {
             "type": "object",
             "additionalProperties": false,
-            "required": [],
+            "required": [
+                "numRecords"
+            ],
             "properties": {
-                "newOffsetInterval": {
-                    "$ref": "/schemas/OffsetInterval",
-                    "description": "Data slice produced by the transaction, if any."
-                },
-                "newWatermark": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Watermark advanced by the transaction, if any."
+                "numRecords": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "description": "Number of records produced by the query"
                 }
             }
         },

--- a/schemas/engine-ops/TransformRequest.json
+++ b/schemas/engine-ops/TransformRequest.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://open-data-fabric.github.com/schemas/ExecuteQueryRequest",
+    "$id": "http://open-data-fabric.github.com/schemas/TransformRequest",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Sent by the coordinator to an engine to perform the next step of data transformation",
     "type": "object",
@@ -41,7 +41,7 @@
         "queryInputs": {
             "type": "array",
             "items": {
-                "$ref": "/schemas/ExecuteQueryRequestInput"
+                "$ref": "/schemas/TransformRequestInput"
             },
             "description": "Defines inputs used in this transaction. Slices corresponding to every input dataset must be present."
         },

--- a/schemas/engine-ops/TransformRequestInput.json
+++ b/schemas/engine-ops/TransformRequestInput.json
@@ -1,7 +1,7 @@
 {
-    "$id": "http://open-data-fabric.github.com/schemas/ExecuteQueryRequestInput",
+    "$id": "http://open-data-fabric.github.com/schemas/TransformRequestInput",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Sent as part of the execute query requst to describe the input",
+    "description": "Sent as part of the engine transform request operation to describe the input",
     "type": "object",
     "additionalProperties": false,
     "required": [

--- a/schemas/engine-ops/TransformResponse.json
+++ b/schemas/engine-ops/TransformResponse.json
@@ -1,0 +1,74 @@
+{
+    "$id": "http://open-data-fabric.github.com/schemas/TransformResponse",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Sent by an engine to coordinator when performing the data transformation",
+    "root": true,
+    "$defs": {
+        "Progress": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [],
+            "properties": {}
+        },
+        "Success": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [],
+            "properties": {
+                "newOffsetInterval": {
+                    "$ref": "/schemas/OffsetInterval",
+                    "description": "Data slice produced by the transaction, if any."
+                },
+                "newWatermark": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Watermark advanced by the transaction, if any."
+                }
+            }
+        },
+        "InvalidQuery": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "Explanation of an error"
+                }
+            }
+        },
+        "InternalError": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "Brief description of an error"
+                },
+                "backtrace": {
+                    "type": "string",
+                    "description": "Details of an error (e.g. a backtrace)"
+                }
+            }
+        }
+    },
+    "oneOf": [
+        {
+            "$ref": "#/$defs/Progress"
+        },
+        {
+            "$ref": "#/$defs/Success"
+        },
+        {
+            "$ref": "#/$defs/InvalidQuery"
+        },
+        {
+            "$ref": "#/$defs/InternalError"
+        }
+    ]
+}

--- a/schemas/fragments/DatasetVocabulary.json
+++ b/schemas/fragments/DatasetVocabulary.json
@@ -1,10 +1,14 @@
 {
   "$id": "http://open-data-fabric.github.com/schemas/DatasetVocabulary",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Lets you manipulate names of the system columns to avoid conflicts.",
+  "description": "Specifies the mapping of system columns onto dataset schema.",
   "type": "object",
   "additionalProperties": false,
-  "required": [],
+  "required": [
+    "systemTimeColumn",
+    "eventTimeColumn",
+    "offsetColumn"
+  ],
   "properties": {
     "systemTimeColumn": {
       "type": "string",

--- a/schemas/fragments/ExecuteTransformInput.json
+++ b/schemas/fragments/ExecuteTransformInput.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://open-data-fabric.github.com/schemas/ExecuteQueryInput",
+  "$id": "http://open-data-fabric.github.com/schemas/ExecuteTransformInput",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Describes a slice of the input dataset used during a transformation",
   "type": "object",

--- a/schemas/metadata-events/ExecuteTransform.json
+++ b/schemas/metadata-events/ExecuteTransform.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://open-data-fabric.github.com/schemas/ExecuteQuery",
+  "$id": "http://open-data-fabric.github.com/schemas/ExecuteTransform",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Indicates that derivative transformation has been performed.",
   "type": "object",
@@ -11,7 +11,7 @@
     "queryInputs": {
       "type": "array",
       "items": {
-        "$ref": "/schemas/ExecuteQueryInput"
+        "$ref": "/schemas/ExecuteTransformInput"
       },
       "description": "Defines inputs used in this transaction. Slices corresponding to every input dataset must be present."
     },

--- a/schemas/metadata-events/MetadataEvent.json
+++ b/schemas/metadata-events/MetadataEvent.json
@@ -7,7 +7,7 @@
       "$ref": "/schemas/AddData"
     },
     {
-      "$ref": "/schemas/ExecuteQuery"
+      "$ref": "/schemas/ExecuteTransform"
     },
     {
       "$ref": "/schemas/Seed"

--- a/schemas/metadata-events/SetVocab.json
+++ b/schemas/metadata-events/SetVocab.json
@@ -1,7 +1,7 @@
 {
   "$id": "http://open-data-fabric.github.com/schemas/SetVocab",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Specifies the mapping of system columns onto dataset schema.",
+  "description": "Lets you manipulate names of the system columns to avoid conflicts.",
   "type": "object",
   "additionalProperties": false,
   "required": [],


### PR DESCRIPTION
Renames `ExecuteQuery` metadata event and the corresponding engine operation to `ExecuteTransform`.

Introduces `RawQuery` engine operation to be used primarily for batch preprocess step of the ingest (but possibly other uses too).