### PR TITLE
Suppress clippy warnings in generated code

### DIFF
--- a/tools/jsonschema_to_rust.py
+++ b/tools/jsonschema_to_rust.py
@@ -9,6 +9,8 @@ PREAMBLE = """//////////////////////////////////////////////////////////////////
 // See: http://opendatafabric.org/
 ///////////////////////////////////////////////////////////////////////////////
 
+#![allow(clippy::all)]
+
 use super::formats::{datetime_rfc3339, datetime_rfc3339_opt};
 use crate::domain::DatasetID;
 use chrono::{DateTime, Utc};
@@ -64,7 +66,7 @@ def read_schemas(schemas_dir):
 def read_schemas_rec(schemas_dir, schemas):
     for fname in os.listdir(schemas_dir):
         path = os.path.join(schemas_dir, fname)
-        
+
         if os.path.isdir(path):
             read_schemas_rec(path, schemas)
             continue

--- a/tools/jsonschema_to_rust_dtos.py
+++ b/tools/jsonschema_to_rust_dtos.py
@@ -11,6 +11,8 @@ PREAMBLE = """
 // See: http://opendatafabric.org/
 ///////////////////////////////////////////////////////////////////////////////
 
+#![allow(clippy::all)]
+
 use crate::identity::*;
 use crate::formats::Multihash;
 use chrono::{DateTime, Utc};
@@ -68,7 +70,7 @@ def read_schemas(schemas_dir):
 def read_schemas_rec(schemas_dir, schemas):
     for fname in os.listdir(schemas_dir):
         path = os.path.join(schemas_dir, fname)
-        
+
         if os.path.isdir(path):
             read_schemas_rec(path, schemas)
             continue

--- a/tools/jsonschema_to_rust_flatbuffers.py
+++ b/tools/jsonschema_to_rust_flatbuffers.py
@@ -14,6 +14,7 @@ PREAMBLE = """
 
 #![allow(unused_variables)]
 #![allow(unused_mut)]
+#![allow(clippy::all)]
 
 use super::proxies_generated as fb;
 mod odf {
@@ -109,7 +110,7 @@ def is_string_enum(typ_or_sch):
 
 def render(schemas_dir):
     schemas = read_schemas(schemas_dir)
-    
+
     # Snapshots always appear in YAML and flatbuffers don't support arrays of unions in Rust yet
     del schemas["DatasetSnapshot"]
 
@@ -161,7 +162,7 @@ def read_schemas(schemas_dir):
 def read_schemas_rec(schemas_dir, schemas):
     for fname in os.listdir(schemas_dir):
         path = os.path.join(schemas_dir, fname)
-        
+
         if os.path.isdir(path):
             read_schemas_rec(path, schemas)
             continue

--- a/tools/jsonschema_to_rust_gql.py
+++ b/tools/jsonschema_to_rust_gql.py
@@ -12,6 +12,7 @@ PREAMBLE = """
 ///////////////////////////////////////////////////////////////////////////////
 
 #![allow(unused_variables)]
+#![allow(clippy::all)]
 
 use chrono::{DateTime, Utc};
 use opendatafabric as odf;
@@ -142,7 +143,7 @@ def read_schemas(schemas_dir):
 def read_schemas_rec(schemas_dir, schemas):
     for fname in os.listdir(schemas_dir):
         path = os.path.join(schemas_dir, fname)
-        
+
         if os.path.isdir(path):
             read_schemas_rec(path, schemas)
             continue

--- a/tools/jsonschema_to_rust_serde_yaml.py
+++ b/tools/jsonschema_to_rust_serde_yaml.py
@@ -10,6 +10,8 @@ PREAMBLE = """
 // See: http://opendatafabric.org/
 ////////////////////////////////////////////////////////////////////////////////
 
+#![allow(clippy::all)]
+
 use std::path::PathBuf;
 use super::formats::{base64, datetime_rfc3339, datetime_rfc3339_opt};
 use crate::*;
@@ -94,7 +96,7 @@ def read_schemas(schemas_dir):
 def read_schemas_rec(schemas_dir, schemas):
     for fname in os.listdir(schemas_dir):
         path = os.path.join(schemas_dir, fname)
-        
+
         if os.path.isdir(path):
             read_schemas_rec(path, schemas)
             continue

--- a/tools/jsonschema_to_rust_traits.py
+++ b/tools/jsonschema_to_rust_traits.py
@@ -11,6 +11,8 @@ PREAMBLE = """
 // See: http://opendatafabric.org/
 ///////////////////////////////////////////////////////////////////////////////
 
+#![allow(clippy::all)]
+
 use crate::dtos;
 use crate::dtos::{CompressionFormat, DatasetKind, SourceOrdering};
 use crate::identity::*;
@@ -85,7 +87,7 @@ def read_schemas(schemas_dir):
 def read_schemas_rec(schemas_dir, schemas):
     for fname in os.listdir(schemas_dir):
         path = os.path.join(schemas_dir, fname)
-        
+
         if os.path.isdir(path):
             read_schemas_rec(path, schemas)
             continue


### PR DESCRIPTION
Related issue: https://github.com/kamu-data/kamu-cli/issues/332