### PR TITLE
v0.34.1: note on case-insensitivity of the dataset name components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.1] - 2024-03-14
+### Changed
+- Added note on case-insensitivity of dataset's name components
+
 ## [0.34.0] - 2024-01-11
 ### Changed
 - [RFC-012: Recommend `base16` encoding for textual representation of hashes and DIDs](rfcs/012-recommend-base16-encoding.md) (#71)

--- a/open-data-fabric.md
+++ b/open-data-fabric.md
@@ -675,6 +675,8 @@ https://opendata.ca/odf/census-2016-population/
 ipfs://bafkreie3hfshd4ikinnbio3kewo2hvj6doh5jp3p23iwk2evgo2un5g7km/
 </pre>
 
+Note that name components such as `DatasetName`, `AccountName`, `RepoName` are case-insensitive, i.e. names `ny-newyork` and `NY-NewYork` are considered identical during lookups and uniqueness checks within the repository.
+
 Full [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar) grammar:
 ```
 DatasetRefAny = 

--- a/open-data-fabric.md
+++ b/open-data-fabric.md
@@ -1,6 +1,6 @@
 # Open Data Fabric
 
-Version: 0.34.0
+Version: 0.34.1
 
 # Abstract
 **Open Data Fabric** is an open protocol specification for decentralized exchange and transformation of semi-structured data that aims to holistically address many shortcomings of the modern data management systems and workflows.

--- a/src/open-data-fabric.md
+++ b/src/open-data-fabric.md
@@ -1,6 +1,6 @@
 # Open Data Fabric
 
-Version: 0.34.0
+Version: 0.34.1
 
 # Abstract
 **Open Data Fabric** is an open protocol specification for decentralized exchange and transformation of semi-structured data that aims to holistically address many shortcomings of the modern data management systems and workflows.

--- a/src/open-data-fabric.md
+++ b/src/open-data-fabric.md
@@ -622,6 +622,8 @@ https://opendata.ca/odf/census-2016-population/
 ipfs://bafkreie3hfshd4ikinnbio3kewo2hvj6doh5jp3p23iwk2evgo2un5g7km/
 </pre>
 
+Note that name components such as `DatasetName`, `AccountName`, `RepoName` are case-insensitive, i.e. names `ny-newyork` and `NY-NewYork` are considered identical during lookups and uniqueness checks within the repository.
+
 Full [PEG](https://en.wikipedia.org/wiki/Parsing_expression_grammar) grammar:
 ```
 DatasetRefAny = 


### PR DESCRIPTION
Clarified case-insensitivity of dataset name components: `DatasetName`, `AccountName`, `RepoName`.